### PR TITLE
Fix testplan features metrics

### DIFF
--- a/feature.tcl
+++ b/feature.tcl
@@ -57,9 +57,10 @@ proc plan {path} {
   }
   foreach section $SECTIONS {
     echo $FEATURES($section) $COVERED($section) [regexp -all {/} $section] $section $COVERAGE($section)
-    coverage attribute -path $section -name Features -value $FEATURES($section)
-    coverage attribute -path $section -name "Features Covered" -value $COVERED($section)
-    coverage attribute -path $section -name "%Features Covered" -value [format "%3.2f%%" [expr ($COVERED($section) / ($FEATURES($section)* 1.0)) * 100.0]]
+#TODO Report Questa tracker bug to display column names with space in it, for now replace space with _
+    coverage attribute -path $section -name "Features" -value $FEATURES($section)
+      coverage attribute -path $section -name "Features_Covered" -value $COVERED($section)
+    coverage attribute -path $section -name "%Features_Covered" -value [format "%3.2f%%" [expr ($COVERED($section) / ($FEATURES($section)* 1.0)) * 100.0]]
   }
 }
 

--- a/regression_vrm_app.rmdb
+++ b/regression_vrm_app.rmdb
@@ -45,6 +45,7 @@
      <postScript launch="exec">
       <!--remove seedDir to ensure we have new random seed for next regression run-->
       <command>rm -rf (%seeddir%)</command>
+      <!--add 3 Features oriented specific metrics to testplan attributes -->
       <command>vsim -c  -do "source (%RMDBDIR%)/feature.tcl ; AddFeatures /testplan (%mergefile%) (%mergefile%) ; quit -f"</command>
     </postScript>
   </runnable>


### PR DESCRIPTION
Questa tracker as a bug when it comes to display attribute names with space character. temporary fix by replacing space with _ but need to report an SR to get it fix in Questa tracker view
